### PR TITLE
Update models for admin compatibility

### DIFF
--- a/registration/model/__init__.py
+++ b/registration/model/__init__.py
@@ -2,6 +2,8 @@
 from tg import config
 from tgext.pluggable import PluggableSession
 
+__all__ = ["Registration"]
+
 DBSession = PluggableSession()
 
 Registration = None

--- a/registration/model/ming_models.py
+++ b/registration/model/ming_models.py
@@ -29,7 +29,7 @@ class Registration(MappedClass):
     password = FieldProperty(s.String, required=True)
     code = FieldProperty(s.String)
     activated = FieldProperty(s.DateTime)
-    extras = FieldProperty(s.Anything)
+    extras = FieldProperty(s.Anything, if_missing=None)
 
     user_id = ForeignIdProperty(app_model.User)
 


### PR DESCRIPTION
Using as a reference the method provided in https://github.com/TurboGears/tgext.pluggable/issues/13, to achieve compatibility with the admin panel all pluggables' models need to list the model classes they want to expose in the admin panel through `__all__`. Using inspection on the module should work as well, but this seems to me a cleaner (and more "pythonic") solution, even if it requires fixing all pluggables that don't already implement `__all__` in their models